### PR TITLE
Replace Environment Variables in Schema Topics Before Validation

### DIFF
--- a/service_test_case.py
+++ b/service_test_case.py
@@ -326,6 +326,11 @@ class NioServiceTestCase(NIOTestCase):
                   'publisher/subscriber topic validation put a json schema '
                   'file in project/tests.'.format(e))
 
+        # replace env vars for schema topics
+        if self._schema:
+            self._schema = {self._replace_env_vars({'topic': topic})['topic']:
+                            self._schema[topic] for topic in self._schema}
+
     def schema_validate(self, signals, topic=None):
         """validate each signal in a list against the given json schema.
         Update any error information to be collected at the end of the test."""


### PR DESCRIPTION
When specifying a json schema file we want to be nio environment agnostic, so we can specify topics like:

`monitor.[[HOSTNAME]].io_status` 

in the file and have that validate topics against specified env variables in the service test.