### PR TITLE
A few fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Each test class can only contain unit tests for one service. These unit tests ar
 
 **Override `subscriber_topics` and `publisher_topics`**<br>If the service has _Subscriber_ or _Publisher_ blocks, override these methods to return a list of the topic names in your service. This allows your tests to publish test signals to the subscribers and to assert against the published signals from the service.
 
+If your service uses _LocalPublisher_ or _LocalSubscriber_ blocks, still use the regular pub/sub topic names provided in your block config. You do not need to prepend the local identifier prefix that those blocks normally do.
+
 **Add `env_vars`**<br>These service tests will not read from any of your project `.env` files so if you want to use some environment variables, override this method and have it return a dictionary that maps environment variable names to values.
 
 ---

--- a/service_test_case.py
+++ b/service_test_case.py
@@ -97,8 +97,9 @@ class NioServiceTestCase(NIOTestCase):
         """notify signals from a block. Adds to a blocks processed signals,
         but does not call block.process_signals.
         """
+        block_id = self.get_block_id(block_name)
         self._router.notify_signals(
-            self._blocks[block_name], signals, terminal)
+            self._blocks[block_id], signals, terminal)
 
     def mock_blocks(self):
         """Optionally create a mocked block class instead of the real thing

--- a/service_test_case.py
+++ b/service_test_case.py
@@ -238,6 +238,7 @@ class NioServiceTestCase(NIOTestCase):
             # use mapping name for block
             block_config["name"] = service_block_id
             block_config["id"] = block_config.get('id', uuid.uuid4())
+            self._override_local_pubsub_block(block_config)
             # instantiate the block
             block = self._init_block(block_config, blocks)
             block_config = self._override_block_config(block_config)
@@ -249,6 +250,17 @@ class NioServiceTestCase(NIOTestCase):
         self._router.configure(RouterContext(
             execution=self.service_config.get("execution", []),
             blocks=self._blocks))
+
+    def _override_local_pubsub_block(self, block_config):
+        """ Set local topic prefixes to empty strings for testing.
+
+        This allows pub/sub topics defined in tests and topic schemas to ignore
+        the presence of a local identifier, which is a rather advanced topic.
+        To not perform this empty string replacement override this method with
+        a simple pass or no-op.
+        """
+        if block_config['type'] in ('LocalPublisher', 'LocalSubscriber'):
+            block_config['local_identifier'] = ''
 
     def start(self):
         # Start blocks


### PR DESCRIPTION
1. Properly handle block names in the `notify_signals` method
2. Utilize https://github.com/nio-blocks/communication/pull/31 and override the local identifier of local pub/sub blocks in a service
3. Allow waiting/processing/asserting on topics of published signals