### PR TITLE
Support format checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Install _jsonschema_ for publisher/subscriber topic validation.
 pip3 install jsonschema
 ```
 
+You may desire to do string format checking on your fields too. For example, make sure a string is an ISO-8601 formatted datetime or a string is a valid email address. To do that, install the `format` extra for `jsonschema`.
+
+```
+pip3 install jsonschema[format]
+```
+
+
 ---
 
 ## Setting up your test class

--- a/service_test_case.py
+++ b/service_test_case.py
@@ -497,7 +497,16 @@ class NioServiceTestCase(NIOTestCase):
         if topic in self._schema:
             for signal in signals:
                 try:
-                    jsonschema.validate(signal.to_dict(), self._schema[topic])
+                    validate_args = {}
+                    if hasattr(jsonschema, 'draft4_format_checker'):
+                        validate_args['format_checker'] = \
+                            jsonschema.draft4_format_checker
+                    jsonschema.validate(
+                        signal.to_dict(),
+                        self._schema[topic],
+                        **validate_args,
+                    )
+
                 except Exception as e:
                     print("Topic {} received an invalid signal: {}"
                           .format(topic, signal))


### PR DESCRIPTION
By installing `jsonschema[format]` you can do additional string format checking like making sure date times or emails are valid.